### PR TITLE
fix: apply control plane role to control plane nodes

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -47,8 +47,9 @@ resource "rhcs_cluster_rosa_classic" "rosa" {
   sts        = local.sts_roles
 
   disable_waiting_in_destroy = false
+  wait_for_create_complete   = true
 
-  depends_on = [module.network, module.account_roles]
+  depends_on = [module.network, module.account_roles_classic, module.operator_roles_classic]
 }
 
 # hosted control plane
@@ -61,8 +62,7 @@ resource "rhcs_cluster_rosa_hcp" "rosa" {
   cloud_region           = var.region
   aws_account_id         = data.aws_caller_identity.current.account_id
   aws_billing_account_id = data.aws_caller_identity.current.account_id
-
-  tags = var.tags
+  tags                   = var.tags
 
   # network
   private            = var.private
@@ -91,13 +91,4 @@ locals {
   cluster_oidc_endpoint_url = var.hosted_control_plane ? rhcs_cluster_rosa_hcp.rosa[0].sts.oidc_config_id : rhcs_cluster_rosa_classic.rosa[0].sts.oidc_endpoint_url
   cluster_api_url           = var.hosted_control_plane ? rhcs_cluster_rosa_hcp.rosa[0].api_url : rhcs_cluster_rosa_classic.rosa[0].api_url
   cluster_console_url       = var.hosted_control_plane ? rhcs_cluster_rosa_hcp.rosa[0].console_url : rhcs_cluster_rosa_classic.rosa[0].console_url
-}
-
-resource "rhcs_cluster_wait" "rosa" {
-  count = var.hosted_control_plane ? 0 : 1
-
-  cluster = local.cluster_id
-  timeout = 60
-
-  depends_on = [module.operator_roles]
 }

--- a/identity.tf
+++ b/identity.tf
@@ -10,8 +10,6 @@ resource "rhcs_identity_provider" "admin" {
       },
     ]
   }
-
-  depends_on = [rhcs_cluster_wait.rosa]
 }
 
 resource "rhcs_identity_provider" "developer" {
@@ -26,8 +24,6 @@ resource "rhcs_identity_provider" "developer" {
       },
     ]
   }
-
-  depends_on = [rhcs_cluster_wait.rosa]
 }
 
 resource "rhcs_group_membership" "admin" {

--- a/roles.tf
+++ b/roles.tf
@@ -1,13 +1,6 @@
 #
 # iam account roles
 #
-locals {
-  openshift_major_version = join(".", slice(split(".", var.ocp_version), 0, 2))
-}
-
-#
-# iam account roles
-#
 
 # classic
 module "account_roles_classic" {

--- a/roles.tf
+++ b/roles.tf
@@ -97,7 +97,7 @@ locals {
   support_role_arn   = var.hosted_control_plane ? "${local.role_prefix}-HCP-ROSA-Support-Role" : "${local.role_prefix}-Support-Role"
 
   # instance roles
-  master_role_arn = var.hosted_control_plane ? null : "${local.role_prefix}-Support-Role"
+  master_role_arn = var.hosted_control_plane ? null : "${local.role_prefix}-ControlPlane-Role"
   worker_role_arn = var.hosted_control_plane ? "${local.role_prefix}-HCP-ROSA-Worker-Role" : "${local.role_prefix}-Worker-Role"
 
   # oidc config

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,5 +1,5 @@
 variable "cluster_name" {
-  default = "dscott-hcp"
+  default = "dscott-classic"
 }
 
 variable "ocp_version" {
@@ -25,7 +25,7 @@ variable "developer_password" {
 module "rosa_public" {
   source = "../"
 
-  hosted_control_plane = true
+  hosted_control_plane = false
   private              = false
   multi_az             = var.multi_az
   autoscaling          = true


### PR DESCRIPTION
This PR does the following:

- Uses the same methodology for HCP for creating OIDC and roles (upstream modules)
- Switches to using the ControlPlane role for the Control Plane nodes (this would fail provisioning previously due to the "Support" role being applied to control plane nodes - a copy/paste error)