### PR TITLE
fix: remove default owner tag

### DIFF
--- a/bastion.tf
+++ b/bastion.tf
@@ -1,3 +1,7 @@
+locals {
+  bastion_tags = merge(var.tags, { "Name" = "${var.cluster_name}-bastion" })
+}
+
 data "aws_ami" "rhel9" {
   count = var.private ? 1 : 0
 
@@ -32,11 +36,7 @@ resource "aws_key_pair" "bastion_host" {
   key_name   = "${var.cluster_name}-bastion"
   public_key = file(var.bastion_public_ssh_key)
 
-  tags = merge(var.tags,
-    {
-      "Name" = "${var.cluster_name}-bastion"
-    }
-  )
+  tags = local.bastion_tags
 }
 
 resource "aws_security_group" "bastion_host" {
@@ -63,11 +63,7 @@ resource "aws_security_group" "bastion_host" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = merge(var.tags,
-    {
-      "Name" = "${var.cluster_name}-bastion"
-    }
-  )
+  tags = local.bastion_tags
 }
 
 resource "aws_instance" "bastion_host" {
@@ -79,11 +75,7 @@ resource "aws_instance" "bastion_host" {
   key_name               = aws_key_pair.bastion_host[0].key_name
   vpc_security_group_ids = [aws_security_group.bastion_host[0].id]
 
-  tags = merge(var.tags,
-    {
-      "Name" = "${var.cluster_name}-bastion"
-    }
-  )
+  tags = local.bastion_tags
 
   user_data = <<EOF
 #!/bin/bash

--- a/modules/terraform-rosa-networking/variables.tf
+++ b/modules/terraform-rosa-networking/variables.tf
@@ -35,12 +35,5 @@ variable "network" {
 variable "tags" {
   description = "Tags applied to all objects"
   type        = map(string)
-  default = {
-    "owner" = "dscott"
-  }
-
-  validation {
-    condition     = (var.tags["owner"] != null && var.tags["owner"] != "")
-    error_message = "Please specify the 'owner' tag as part of 'var.tags'."
-  }
+  default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -60,9 +60,7 @@ variable "service_cidr" {
 variable "tags" {
   description = "Tags applied to all objects"
   type        = map(string)
-  default = {
-    "owner" = "dscott"
-  }
+  default     = {}
 }
 
 variable "admin_password" {


### PR DESCRIPTION
This always defaulted to dscott.  We should remove the owner requirement as well as the default owner tag and enforce this another way if we want an owner enforced.  This is due to the high probability that organizations that consume this module do not use an owner tag and have other tagging requirements.