### PR TITLE
fix: admin group membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 This repository can be used as a module to create a ROSA cluster with the following components:
 
 - ROSA networking in either private/public architecture
-- ROSA cluster in either "Classic" or "Hosted Control Plane" architecture
-- Machine Pool with desired replica count
-- Local HTPasswd identity provider with an "admin" user with Cluster Admin privileges
-- Local HTPasswd identity provider with an "developer" user with basic privileges
+- ROSA cluster in either [Classic](https://docs.openshift.com/rosa/architecture/rosa-architecture-models.html#rosa-classic-architecture_rosa-architecture-models) 
+or [Hosted Control Plane](https://docs.openshift.com/rosa/architecture/rosa-architecture-models.html#rosa-hcp-architecture_rosa-architecture-models) architecture
+- [Default machine pool](https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.html) with desired replica count
+- Local HTPasswd [identity provider](https://docs.openshift.com/rosa/authentication/sd-configuring-identity-providers.html) with an "admin" user with Cluster Admin privileges
+- Local HTPasswd [identity provider](https://docs.openshift.com/rosa/authentication/sd-configuring-identity-providers.html) with an "developer" user with basic privileges
 
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# Summary
+
+This repository can be used as a module to create a ROSA cluster with the following components:
+
+- ROSA networking in either private/public architecture
+- ROSA cluster in either "Classic" or "Hosted Control Plane" architecture
+- Machine Pool with desired replica count
+- Local HTPasswd identity provider with an "admin" user with Cluster Admin privileges
+- Local HTPasswd identity provider with an "developer" user with basic privileges
+
+
+# Usage
+
+The following Terraform is an example file to deploy a public ROSA cluster via this module.  This file
+can be created in wherever you want to run Terraform at as a `main.tf` file.  A complete list of variables
+and modifications is available via the [variables.tf](variables.tf) file:
+
+**NOTE:** this is an overly simplistic file to demonstrate a simple installation.  You will need to tailor your 
+automation to your needs.  If there is functionality that is missing that you would like to see, please open an issue!
+
+```
+variable "token" {
+  type      = string
+  sensitive = true
+}
+
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "developer_password" {
+  type      = string
+  sensitive = true
+}
+
+module "rosa_public" {
+  source = "git::https://github.com/rh-mobb/terraform-rosa.git?ref=v0.0.1?ref=main"
+
+  hosted_control_plane = false
+  private              = false
+  multi_az             = false
+  autoscaling          = false
+  cluster_name         = "my-rosa-cluster"
+  ocp_version          = "4.15.14"
+  token                = var.token
+  admin_password       = var.admin_password
+  developer_password   = var.developer_password
+  pod_cidr             = "10.128.0.0/14"
+  service_cidr         = "172.30.0.0/16"
+
+  tags = {
+    "owner" = "me"
+  }
+}
+```
+
+Once the above has been created, normal Terraform commands can be run:
+
+```bash
+terraform init
+terraform plan rosa.out
+terraform apply rosa.out
+```

--- a/bastion.tf
+++ b/bastion.tf
@@ -88,14 +88,11 @@ sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/late
 sudo systemctl enable amazon-ssm-agent
 sudo systemctl start amazon-ssm-agent
 
-# mitmproxy
-
+# openshift/kubernetes clients
 wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
-
 mkdir openshift
 tar -zxvf openshift-client-linux.tar.gz -C openshift
 sudo install openshift/oc /usr/local/bin/oc
 sudo install openshift/kubectl /usr/local/bin/kubectl
 EOF
-
 }

--- a/identity.tf
+++ b/identity.tf
@@ -1,14 +1,22 @@
+locals {
+  # admin idp
+  admin_username = "admin"
+  admin_group    = "cluster-admins"
+
+  # developer idp
+  developer_username = "developer"
+}
+
 resource "rhcs_identity_provider" "admin" {
   count = var.admin_password != null && var.admin_password != "" ? 1 : 0
 
   cluster = local.cluster_id
-  name    = "admin"
+  name    = local.admin_username
   htpasswd = {
     users = [{
-      username = "admin"
+      username = local.admin_username
       password = var.admin_password
-      },
-    ]
+    }]
   }
 }
 
@@ -16,20 +24,19 @@ resource "rhcs_identity_provider" "developer" {
   count = var.developer_password != null && var.developer_password != "" ? 1 : 0
 
   cluster = local.cluster_id
-  name    = "developer"
+  name    = local.developer_username
   htpasswd = {
     users = [{
-      username = "developer"
+      username = local.developer_username
       password = var.developer_password
-      },
-    ]
+    }]
   }
 }
 
 resource "rhcs_group_membership" "admin" {
-  user    = "admin"
-  group   = "cluster-admins"
-  cluster = local.cluster_id
+  count = var.admin_password != null && var.admin_password != "" ? 1 : 0
 
-  depends_on = [rhcs_identity_provider.admin]
+  user    = rhcs_identity_provider.admin[0].htpasswd.users[0].username
+  group   = local.admin_group
+  cluster = local.cluster_id
 }

--- a/roles.tf
+++ b/roles.tf
@@ -87,7 +87,7 @@ module "operator_roles_hcp" {
 
 #
 # sts role block
-#   NOTE: this is the sts role black that is passed into the cluster creation process
+#   NOTE: this is the sts role block that is passed into the cluster creation process
 #
 locals {
   role_prefix = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.cluster_name}"


### PR DESCRIPTION
This PR addresses the following:

- Adds the `count` to the `rhcs_group_membership` resource.  Previously, this would fail if an admin user was not requested
- Small formatting.  Add and re-use locals and chain `rhcs_identity_provider.admin` to `rhcs_group_membership.admin`
- Add a based `README` to the root of the repo