### PR TITLE
feat: replica counts provider updates and other various updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ module "rosa_public" {
   hosted_control_plane = false
   private              = false
   multi_az             = false
-  autoscaling          = false
+  replicas             = 2
+  max_replicas         = 4
   cluster_name         = "my-rosa-cluster"
   ocp_version          = "4.15.14"
   token                = var.token

--- a/cluster.tf
+++ b/cluster.tf
@@ -27,11 +27,12 @@ resource "rhcs_cluster_rosa_classic" "rosa" {
   aws_account_id = data.aws_caller_identity.current.account_id
   tags           = var.tags
 
-  # autoscaling
-  autoscaling_enabled = var.autoscaling
-  min_replicas        = var.autoscaling ? local.autoscaling_min : null
-  max_replicas        = var.autoscaling ? local.autoscaling_max : null
-  replicas            = var.autoscaling ? null : coalesce(var.replicas, local.default_replicas)
+  # autoscaling and instance settings
+  compute_machine_type = var.compute_machine_type
+  autoscaling_enabled  = var.autoscaling
+  min_replicas         = var.autoscaling ? local.autoscaling_min : null
+  max_replicas         = var.autoscaling ? local.autoscaling_max : null
+  replicas             = var.autoscaling ? null : coalesce(var.replicas, local.default_replicas)
 
   # network
   private            = var.private
@@ -42,9 +43,6 @@ resource "rhcs_cluster_rosa_classic" "rosa" {
   multi_az           = var.multi_az
   pod_cidr           = var.pod_cidr
   service_cidr       = var.service_cidr
-
-  # instance type
-  compute_machine_type = var.compute_machine_type
 
   # rosa / openshift
   properties = { rosa_creator_arn = data.aws_caller_identity.current.arn }
@@ -69,6 +67,10 @@ resource "rhcs_cluster_rosa_hcp" "rosa" {
   aws_billing_account_id = data.aws_caller_identity.current.account_id
   tags                   = var.tags
 
+  # autoscaling and instance settings
+  compute_machine_type = var.compute_machine_type
+  replicas             = coalesce(var.replicas, local.default_replicas)
+
   # network
   private            = var.private
   aws_subnet_ids     = local.subnet_ids
@@ -82,18 +84,11 @@ resource "rhcs_cluster_rosa_hcp" "rosa" {
   version    = var.ocp_version
   sts        = local.sts_roles
 
-  # instance type
-  compute_machine_type = var.compute_machine_type
-
-  # replicas
-  replicas = coalesce(var.replicas, local.default_replicas)
-
   disable_waiting_in_destroy          = false
   wait_for_create_complete            = true
   wait_for_std_compute_nodes_complete = true
 
   depends_on = [module.network, module.account_roles_hcp, module.operator_roles_hcp]
-
 }
 
 locals {

--- a/provider.tf
+++ b/provider.tf
@@ -9,6 +9,11 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.20.0"
     }
+
+    validation = {
+      source  = "tlkamp/validation"
+      version = "1.1.1"
+    }
   }
 }
 

--- a/provider.tf
+++ b/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     rhcs = {
-      version = ">= 1.6.1"
+      version = ">= 1.6.2"
       source  = "terraform-redhat/rhcs"
     }
 

--- a/test/main.tf
+++ b/test/main.tf
@@ -7,7 +7,7 @@ variable "ocp_version" {
 }
 
 variable "multi_az" {
-  default = false
+  default = true
 }
 
 variable "token" {
@@ -28,7 +28,8 @@ module "rosa_public" {
   hosted_control_plane = false
   private              = false
   multi_az             = var.multi_az
-  autoscaling          = true
+  replicas             = 3
+  max_replicas         = 3
   cluster_name         = var.cluster_name
   ocp_version          = var.ocp_version
   token                = var.token
@@ -36,6 +37,10 @@ module "rosa_public" {
   developer_password   = var.developer_password
   pod_cidr             = "10.128.0.0/14"
   service_cidr         = "172.30.0.0/16"
+
+  # NOTE: this variable is deprecated.  setting both replicas and max_replicas 
+  #       will enable autoscaling. 
+  # autoscaling = true
 
   tags = {
     "cost-center"   = "CC468"

--- a/variables.tf
+++ b/variables.tf
@@ -1,86 +1,116 @@
 variable "private" {
-  type    = bool
-  default = false
+  description = "Set to true to provision a private cluster, which restricts access from the public internet."
+  type        = bool
+  default     = false
 }
 
 variable "bastion_public_ssh_key" {
-  type    = string
-  default = "~/.ssh/id_rsa.pub"
+  description = <<EOF
+  Location to an SSH public key file on the local system which is used to provide connectivity to the bastion host
+  when the 'private' variable is set to 'true'.
+  EOF
+  type        = string
+  default     = "~/.ssh/id_rsa.pub"
 }
 
 variable "region" {
-  type    = string
-  default = "us-east-1"
+  description = "The AWS region to provision a ROSA cluster and required components into."
+  type        = string
+  default     = "us-east-1"
 }
 
 variable "multi_az" {
-  type    = bool
-  default = false
+  description = <<EOF
+  Configure the cluster to use a highly available, multi availability zone configuration.  It should be noted that use
+  of the 'multi_az' variable may affect minimum requirements for 'replicas' and may restrict regions that do not have 
+  three availability zones.
+  EOF
+  type        = bool
+  default     = false
 }
 
 variable "hosted_control_plane" {
-  type    = bool
-  default = false
+  description = "Provision a ROSA cluster using a Hosted Control Plane."
+  type        = bool
+  default     = false
 }
 
 variable "autoscaling" {
+  description = <<EOF
+  Enable autoscaling for the default machine pool, this is ignored for HCP clusters as autoscaling is not supported
+  for Hosted Control Plane clusters at this time.
+  EOF
   type        = bool
   default     = true
-  description = "Enable autoscaling for the default machine pool, this is ignored for HCP clusters"
 }
 
 variable "replicas" {
+  description = "Number of replicas for the default machine pool, this is ignored if autoscaling is enabled."
   type        = number
   nullable    = true
   default     = null
-  description = "Number of replicas for the default machine pool, this is ignored if autoscaling is enabled"
 }
 
 variable "token" {
-  type      = string
-  sensitive = true
+  description = <<EOF
+  OCM token used to authenticate against the OpenShift Cluster Manager API.  See
+  https://console.redhat.com/openshift/token/rosa/show to access your token.
+  EOF
+  type        = string
+  sensitive   = true
 }
 
 variable "cluster_name" {
-  type = string
+  description = "The name of the cluster.  This is also used as a prefix to name related components."
+  type        = string
 }
 
 variable "ocp_version" {
-  type    = string
-  default = "4.14.7"
+  description = <<EOF
+  The version of OpenShift to use.  You can use the command 'rosa list versions' to see all available OpenShift 
+  versions available to ROSA.
+  EOF
+  type        = string
+  default     = "4.15.18"
 }
 
 variable "vpc_cidr" {
-  type    = string
-  default = "10.10.0.0/16"
+  description = "The CIDR of the VPC that will be created."
+  type        = string
+  default     = "10.10.0.0/16"
 }
 
 variable "subnet_cidr_size" {
-  type    = number
-  default = 20
+  description = <<EOF
+  The CIDR size of each of the individual subnets that will be created.  Must be within range of the 'vpc_cidr' 
+  variable.
+  EOF
+  type        = number
+  default     = 20
 }
 
 variable "pod_cidr" {
-  type    = string
-  default = "10.128.0.0/14"
+  description = "The internal pod CIDR network used for assigning IP addresses to pods."
+  type        = string
+  default     = "10.128.0.0/14"
 }
 
 variable "service_cidr" {
-  type    = string
-  default = "172.30.0.0/16"
+  description = "The internal service CIDR network used for assigning IP addresses to services."
+  type        = string
+  default     = "172.30.0.0/16"
 }
 
 variable "tags" {
-  description = "Tags applied to all objects"
+  description = "Tags applied to all objects."
   type        = map(string)
   default     = {}
 }
 
 variable "admin_password" {
   description = <<EOF
-  Password for the 'admin' user. IDP is not created if unspecified.
-
-  Password must be 14 characters or more, contain one uppercase letter and a symbol or number.
+  Password for the 'admin' user. IDP is not created if unspecified.  Password must be 14 characters or more, contain 
+  one uppercase letter and a symbol or number.
   EOF
   type        = string
   sensitive   = true
@@ -88,16 +118,18 @@ variable "admin_password" {
 
 variable "developer_password" {
   description = <<EOF
-  Password for the 'developer' user. IDP is not created if unspecified.
-
-  Password must be 14 characters or more, contain one uppercase letter and a symbol or number.
+  Password for the 'developer' user. IDP is not created if unspecified.  Password must be 14 characters or more, contain 
+  one uppercase letter and a symbol or number.
   EOF
   type        = string
   sensitive   = true
 }
 
 variable "compute_machine_type" {
-  description = "The machine type used by the initial worker nodes, for example, m5.xlarge."
+  description = <<EOF
+  The machine type used by the initial worker nodes, for example, m5.xlarge.  You can use the command 'rosa list 
+  instance-types' to see all available instance types available to ROSA.
+  EOF
   type        = string
   default     = "m5.xlarge"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -39,13 +39,31 @@ variable "autoscaling" {
   description = <<EOF
   Enable autoscaling for the default machine pool, this is ignored for HCP clusters as autoscaling is not supported
   for Hosted Control Plane clusters at this time.
+
+  WARN: this variable is deprecated.  Simply setting 'max_replicas' will enable autoscaling.  This will be removed 
+  in a future version of this module.
   EOF
   type        = bool
-  default     = true
+  nullable    = true
+  default     = null
 }
 
 variable "replicas" {
-  description = "Number of replicas for the default machine pool, this is ignored if autoscaling is enabled."
+  description = <<EOF
+  Minimum number of replicas for the default machine pool.  If unset, a default value is configured based on the 
+  'multi_az' value.
+  EOF
+  type        = number
+  nullable    = true
+  default     = null
+}
+
+variable "max_replicas" {
+  description = <<EOF
+  Maximum number of replicas for the default machine pool.  If set, autoscaling is enabled for classic clusters.  
+  Autoscaling is unsupported via Terraform for HCP clusters, so this value is always ignored when 'hosted_control_plane'
+  is set to 'true'.  This value must be equal to or higher than the 'replicas' value if set.
+  EOF
   type        = number
   nullable    = true
   default     = null


### PR DESCRIPTION
The following is changed in this PR:

- Allow ability to select replica count for the default machine pool
- Deprecate the `autoscaling` variable in favor of `replicas` and `max_replicas`.  Configuring both will enable autoscaling.
- Upgrade `rhcs` provider to latest version
- Add description to all variables for better documentation
- Other small refactors