### PR TITLE
adding cluster_id as an output to the rosa module

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -41,3 +41,7 @@ output "cluster_api_url" {
 output "cluster_console_url" {
   value = local.cluster_console_url
 }
+
+output "cluster_id" {
+  value = local.cluster_id
+}


### PR DESCRIPTION
need cluster_id to be available as an output in order to consume downstream