### PR TITLE
Fix provisioning for hcp cluster with billing account #22

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -100,7 +100,13 @@ resource "rhcs_cluster_rosa_hcp" "rosa" {
   # aws
   cloud_region           = var.region
   aws_account_id         = data.aws_caller_identity.current.account_id
-  aws_billing_account_id = data.aws_caller_identity.current.account_id
+  
+  if var.aws_billing_account_id != null {
+      aws_billing_account_id = var.aws_billing_account_id
+    } else {
+      aws_billing_account_id = data.aws_caller_identity.current.account_id 
+  }
+
   tags                   = var.tags
 
   # autoscaling and instance settings

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,12 @@ variable "bastion_public_ip" {
   default = false
 }
 
+variable "aws_billing_account_id" {
+  description = "The AWS billing account identifier where all resources are billed. If no information is provided, the data will be retrieved from the currently connected account."
+  type        = string
+  default     = null
+}
+
 variable "region" {
   description = "The AWS region to provision a ROSA cluster and required components into."
   type        = string


### PR DESCRIPTION
In my organization the billing account is different from the AWS infra provisioning account,  add the necessary input and code to handle it if needed.

Added the "aws_billing_account_id" module input to variables.tf
and check against it in cluster.tf if none is defined 