### PR TITLE
feat: upgrade module versions

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     rhcs = {
-      version = ">= 1.6.2"
+      version = ">= 1.6.4"
       source  = "terraform-redhat/rhcs"
     }
 

--- a/roles.tf
+++ b/roles.tf
@@ -7,7 +7,7 @@ module "account_roles_classic" {
   count = var.hosted_control_plane ? 0 : 1
 
   source  = "terraform-redhat/rosa-classic/rhcs//modules/account-iam-resources"
-  version = "1.6.2"
+  version = "1.6.3"
 
   account_role_prefix = var.cluster_name
   openshift_version   = local.classic_version
@@ -19,7 +19,7 @@ module "account_roles_hcp" {
   count = var.hosted_control_plane ? 1 : 0
 
   source  = "terraform-redhat/rosa-hcp/rhcs//modules/account-iam-resources"
-  version = "1.6.2"
+  version = "1.6.3"
 
   account_role_prefix = var.cluster_name
   tags                = var.tags
@@ -34,7 +34,7 @@ module "oidc_config_and_provider_classic" {
   count = var.hosted_control_plane ? 0 : 1
 
   source  = "terraform-redhat/rosa-classic/rhcs//modules/oidc-config-and-provider"
-  version = "1.6.2"
+  version = "1.6.3"
 
   managed = true
   tags    = var.tags
@@ -44,7 +44,7 @@ module "operator_policies_classic" {
   count = var.hosted_control_plane ? 0 : 1
 
   source  = "terraform-redhat/rosa-classic/rhcs//modules/operator-policies"
-  version = "1.6.2"
+  version = "1.6.3"
 
   account_role_prefix = var.cluster_name
   openshift_version   = local.classic_version
@@ -55,7 +55,7 @@ module "operator_roles_classic" {
   count = var.hosted_control_plane ? 0 : 1
 
   source  = "terraform-redhat/rosa-classic/rhcs//modules/operator-roles"
-  version = "1.6.2"
+  version = "1.6.3"
 
   operator_role_prefix = var.cluster_name
   account_role_prefix  = module.operator_policies_classic[0].account_role_prefix
@@ -68,7 +68,7 @@ module "oidc_config_and_provider_hcp" {
   count = var.hosted_control_plane ? 1 : 0
 
   source  = "terraform-redhat/rosa-hcp/rhcs//modules/oidc-config-and-provider"
-  version = "1.6.2"
+  version = "1.6.3"
 
   managed = true
   tags    = var.tags
@@ -78,7 +78,7 @@ module "operator_roles_hcp" {
   count = var.hosted_control_plane ? 1 : 0
 
   source  = "terraform-redhat/rosa-hcp/rhcs//modules/operator-roles"
-  version = "1.6.2"
+  version = "1.6.3"
 
   oidc_endpoint_url    = module.oidc_config_and_provider_hcp[0].oidc_endpoint_url
   operator_role_prefix = var.cluster_name


### PR DESCRIPTION
This implements the fix where modules that are called from upstream use the >= operator to grab minimum avaialble provider versions and not specific versions to avoid conflicts when customers use the rhcs_cluster_rosa_hcp resource with the modules.