### PR TITLE
Fix broken query for AZs in region

### DIFF
--- a/modules/terraform-rosa-networking/data.tf
+++ b/modules/terraform-rosa-networking/data.tf
@@ -7,8 +7,8 @@ data "aws_availability_zones" "available" {
   }
 
   filter {
-    name   = "group-name"
-    values = [data.aws_region.current.name]
+    name = "zone-type"
+    values = ["availability-zone"]
   }
 
   filter {


### PR DESCRIPTION
Fix a bug where no AZs could be found in a region, due to an AWS API change, by relying on the zone-type field to filter rather than the group-name.

When finding a set of AZs in a region, we need to be able to filter to only the AZs that are actually Availability Zones (and not Local Zones nor Wavelength Zones).

We used to be able to do this by filtering on zones whose group name matches the region name, as documented in
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AvailabilityZone.html#API_AvailabilityZone_Contents However, in Oct 2024, AWS changed the contents of the group-name field to reflect a new Zone Group model.

Therefore, instead explicitly filter for zone-type=availability-zone.